### PR TITLE
Improved dependency versions for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.6",
-        "behat/behat": ">=2.4.0,<2.5.0-dev",
+        "behat/behat": ">=2.4.0",
         "symfony/config": "~2.0",
         "symfony/dependency-injection": "~2.0",
         "monolog/monolog": "1.2.*"

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=5.3.6",
         "behat/behat": ">=2.4.0,<2.5.0-dev",
-        "symfony/config": ">=2.0.0,<2.2.0",
-        "symfony/dependency-injection": ">=2.0.0,<2.2.0",
+        "symfony/config": "~2.0",
+        "symfony/dependency-injection": "~2.0",
         "monolog/monolog": "1.2.*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "behat/behat": ">=2.4.0",
         "symfony/config": "~2.0",
         "symfony/dependency-injection": "~2.0",
-        "monolog/monolog": "1.2.*"
+        "monolog/monolog": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "3.7.*"


### PR DESCRIPTION
Extension cannot be installed with the latest versions of Symfony,  Behat nor Monolog atm, while it runs with them perfectly fine.
